### PR TITLE
Fix an off-by-one date bug

### DIFF
--- a/src/components/FormattedDate.astro
+++ b/src/components/FormattedDate.astro
@@ -12,6 +12,7 @@ const { date } = Astro.props;
 			year: 'numeric',
 			month: 'short',
 			day: '2-digit',
+			timeZone: 'UTC',
 		})
 	}
 </time>


### PR DESCRIPTION
Treats the formatted dates as UTC, avoiding skewing the date based on the local timezone.